### PR TITLE
Update for Clojure 1.10.1, assorted dependency upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Interval Treeset
 
+This is a fork of [dthume's
+data.interval-tree](https://github.com/dthume/data.interval-tree), purely to
+support newer versions of Clojure. It looks like David might be AFK for a bit;
+hopefully he'll come back and this can go away!
+
+I've changed the project name (for Clojars), but left the namespaces under
+org.dthume; it should be a drop-in replacement for the original.
+
+## About
+
 Interval Treeset built on [data.finger-tree](https://github.com/clojure/data.finger-tree).
 
 Largely based on the implementation described in the

--- a/project.clj
+++ b/project.clj
@@ -9,15 +9,14 @@
 
   :plugins [[codox "0.8.9"]
             [lein-marginalia "0.7.1"]
-            [lein-midje "3.0.0"]
-            [perforate "0.3.3"]]
+            [lein-midje "3.2.1"]
+            [perforate "0.3.4"]]
 
   :codox {:defaults {:doc/format :markdown}
           :output-dir "doc/codox"}
 
-  :dependencies [[clj-tuple "0.1.6"]
-                 [org.clojure/clojure "1.6.0"]
-                 [org.clojure/data.finger-tree "0.0.2"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/data.finger-tree "0.0.3"]
                  [org.dthume/data.set "0.1.1"]]
 
   :javac-options ["-target" "1.6" "-source" "1.6"]
@@ -28,10 +27,10 @@
   :profiles
   {:dev
    {:source-paths ["src/dev/clj"]
-    :dependencies [[midje "1.6.3"]
-                   [perforate "0.3.3"]
-                   [org.clojure/test.check "0.5.9"]
-                   [collection-check "0.1.4"]]}
+    :dependencies [[midje "1.9.9"]
+                   [perforate "0.3.4"]
+                   [org.clojure/test.check "1.1.0"]
+                   [collection-check "0.1.6"]]}
 
    :benchmark
    {:jvm-opts ^:replace
@@ -44,7 +43,7 @@
   {"ci-build"
    ^{:doc "Perform the Continuous Integration build"}
    ["do" ["clean"] ["check"] ["midje"]]
-   
+
    "dev-bench"
    ^{:doc "Run development benchmarks"}
    ["with-profile" "benchmark" "perforate"]

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject org.dthume/data.interval-treeset "0.1.3-SNAPSHOT"
+(defproject com.aphyr/data.interval-treeset "0.1.3"
   :description "Interval Treeset based on finger trees."
-  :url "http://github.com/dthume/data.interval-tree"
+  :url "http://github.com/aphyr/data.interval-tree"
   :license {:name "Eclipse Public License 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :scm {:name "git"
-        :url "github.com/dthume/data.interval-tree"}
+        :url "github.com/aphyr/data.interval-tree"}
 
   :plugins [[codox "0.8.9"]
             [lein-marginalia "0.7.1"]
@@ -67,4 +67,4 @@
       "--name" "data.interval-treeset Walkthrough"
       "--desc" "An introduction to data.interval-treeset"
       "--file" "walkthrough.html"
-      "test/org/dthume/data/test_interval_treeset.clj"]]]})
+      "test/com/aphyr/data/test_interval_treeset.clj"]]]})

--- a/src/org/dthume/data/interval_treeset/selection.clj
+++ b/src/org/dthume/data/interval_treeset/selection.clj
@@ -1,8 +1,7 @@
 (ns ^{:doc "Interval treeset subset selection."}
   org.dthume.data.interval-treeset.selection
   (:refer-clojure :exclude [-> ->> as->])
-  (:require [clj-tuple :refer (tuple)]
-            [clojure.core.reducers :as r]
+  (:require [clojure.core.reducers :as r]
             [clojure.data.finger-tree :as ft]
             [org.dthume.data.interval-treeset :as it]
             [org.dthume.data.set :as set])
@@ -11,7 +10,7 @@
 (defn selection
   "Create a selection from 3 trees: `pre`fix `sel`ected and `suff`ix."
   [pre sel suff]
-  (tuple pre sel suff))
+  [pre sel suff])
 
 (defn selected
   "Lensing function for the selected component part of a region.
@@ -113,7 +112,7 @@ component part value."
     (if (and (some? rs) (pos? n))
       (let [r (first rs)]
         (recur (conj p r) (next rs) (if (pred r) (dec n) n)))
-      (tuple p rs (suffix t)))))
+      [p rs (suffix t)])))
 
 (defn contractl-while
   "Contract the covered region to the left while `pred` returns logical `true`."
@@ -121,7 +120,7 @@ component part value."
   (loop [p (prefix t) rs (selected t)]
     (if (and (some? rs) (pred (first rs)))
       (recur (conj p (first rs)) (next rs))
-      (tuple p rs (suffix t)))))
+      [p rs (suffix t)])))
 
 (defn contractl
   "Contract the covered region to the left by `n` items."
@@ -134,7 +133,7 @@ component part value."
   [t pred n]
   (loop [p (prefix t) r (selected t) n n]
     (if (or (empty? p) (zero? n))
-      (tuple p r (suffix t))
+      [p r (suffix t)]
       (recur (pop p) (conj r (peek p))
              (if (pred (peek p)) (dec n) n)))))
 
@@ -143,7 +142,7 @@ component part value."
   [t pred]
   (loop [p (prefix t) r (selected t)]
     (if (or (empty? p) (pred (peek p)))
-      (tuple p r (suffix t))
+      [p r (suffix t)]
       (recur (pop p) (conj r (peek p))))))
 
 (defn expandl
@@ -157,7 +156,7 @@ component part value."
   [t pred n]
   (loop [r (selected t) s (suffix t) n n]
     (if (or (empty? r) (zero? n))
-      (tuple (prefix t) r s)
+      [(prefix t) r s]
       (recur (pop r) (conj s (peek r))
              (if (pred (peek r)) (dec n) n)))))
 
@@ -166,7 +165,7 @@ component part value."
   [t pred]
   (loop [r (selected t) s (selected t)]
     (if (or (empty? r) (pred (peek r)))
-      (tuple (prefix t) r s)
+      [(prefix t) r s]
       (recur (pop r) (conj s (peek r))))))
 
 (defn contractr
@@ -183,7 +182,7 @@ component part value."
       (let [s (first ss)]
         (recur (conj r s) (next ss)
                (if (pred s) (dec n) n)))
-      (tuple (prefix t) r ss))))
+      [(prefix t) r ss])))
 
 (defn expandr-while
   "Expand the covered region to the right while `pred` evaluates to logical
@@ -191,7 +190,7 @@ component part value."
   [t pred]
   (loop [r (selected t) ss (suffix t)]
     (if (or (empty? ss) (not (pred (first ss))))
-      (tuple (prefix t) r ss)
+      [(prefix t) r ss]
       (recur (conj r (first ss)) (next ss)))))
 
 (defn expandr
@@ -208,7 +207,7 @@ component part value."
          s (suffix t)
          n n]
     (if (or (empty? p) (zero? n))
-      (tuple p r s)
+      [p r s]
       (recur (pop p)
              (clojure.core/-> r (conj (peek p)) pop)
              (conj (peek r) s)
@@ -221,7 +220,7 @@ component part value."
          r (selected t)
          s (suffix t)]
     (if (or (empty? p) (pred (peek p)))
-      (tuple p r s)
+      [p r s]
       (recur (pop p)
              (clojure.core/-> r (conj (peek p)) pop)
              (conj (peek r) s)))))
@@ -240,7 +239,7 @@ component part value."
          s (suffix t)
          n n]
     (if (or (empty? s) (zero? n))
-      (tuple p r s)
+      [p r s]
       (recur (conj p (first r))
              (clojure.core/-> r next (conj (peek s)))
              (next s)
@@ -253,7 +252,7 @@ component part value."
          r (selected t)
          s (suffix t)]
     (if (or (empty? s) (pred (first s)))
-      (tuple p r s)
+      [p r s]
       (recur (conj p (first r))
              (clojure.core/-> r next (conj (peek s)))
              (next s)))))


### PR DESCRIPTION
Hi there! It looks like data.interval-tree doesn't work with recent versions of Clojure, owing, I think, to clj-tuple being folded into Clojure itself. I've gone through and removed the dependency on clj-tuple and bumped assorted other libraries. No API changes, and tests now pass with Clojure 1.10.1. :-)